### PR TITLE
kill request if there are no [more] available translation samples

### DIFF
--- a/reverso_context_api/client.py
+++ b/reverso_context_api/client.py
@@ -60,7 +60,7 @@ class Client(object):
                 # stop the request if there is no available translation sample               
                 # if that is not done, the program will make requests endlessly until
                 # the server throws a 429 exception. 
-                return False
+                break 
             for entry in page["list"]:
                 source_text, translation = entry["s_text"], entry["t_text"]
                 if cleanup:

--- a/reverso_context_api/client.py
+++ b/reverso_context_api/client.py
@@ -56,11 +56,7 @@ class Client(object):
          'In order to achieve good consumer protection, international rules are required.')
         """
         for page in self._translations_pager(text, target_text, source_lang, target_lang):
-            if page["list"] == []:
-                # stop the request if there is no available translation sample               
-                # if that is not done, the program will make requests endlessly until
-                # the server throws a 429 exception. 
-                break 
+
             for entry in page["list"]:
                 source_text, translation = entry["s_text"], entry["t_text"]
                 if cleanup:
@@ -124,6 +120,10 @@ class Client(object):
             pages_total = contents["npages"]
             yield contents
             page_num += 1
+
+            # if the page has no examples, or has ran out of them, stop iterating.
+            if contents["list"] == []:
+                break
 
     def _favorites_pager(self, source_lang=None, target_lang=None):
         source_lang = source_lang or self._source_lang

--- a/reverso_context_api/client.py
+++ b/reverso_context_api/client.py
@@ -56,6 +56,11 @@ class Client(object):
          'In order to achieve good consumer protection, international rules are required.')
         """
         for page in self._translations_pager(text, target_text, source_lang, target_lang):
+            if page["list"] == []:
+                # stop the request if there is no available translation sample               
+                # if that is not done, the program will make requests endlessly until
+                # the server throws a 429 exception. 
+                return False
             for entry in page["list"]:
                 source_text, translation = entry["s_text"], entry["t_text"]
                 if cleanup:


### PR DESCRIPTION
Ой, братишка! Greetings from Brazil. Your API has been of great use to me. I'm using it to create material to study Russian on Anki. There was a little problem where if you made a request for translation samples for an entry that is not available on Reverso Context it would never stop doing the request, and then the server would inevitably throw a 429 exception (and if this kept happening your IP would be temporarily blocked from making requests, which is awful). Same thing would happen if you asked for a number of samples for a given word, but the number of available samples on Reverso Context for that word is smaller than the number you requested.

Anyway, my solution is not the most elegant but I think it solves the problem.